### PR TITLE
supports nested XML with concealed elements for better privacy.

### DIFF
--- a/bbc1/lib/registry_lib.py
+++ b/bbc1/lib/registry_lib.py
@@ -197,13 +197,20 @@ class Document:
         self.root = root
 
 
-    def file(self):
+    def file(self, container=None):
+
+        if container is None:
+            container = self.root
 
         dat = bytearray()
-        for e in self.root:
+        for e in container:
             if e.tag == 'digest':
                 digest = binascii.a2b_hex(e.text)
                 dat.extend(digest)
+            elif 'container' in e.attrib and e.attrib['container'] == 'true' \
+                    and len(e) > 0:
+                d = self.file(e)
+                dat.extend(hashlib.sha256(d).digest())
             else:
                 string = ET.tostring(e, encoding="utf-8")
                 dat.extend(hashlib.sha256(string).digest())

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ bbc1_classifiers = [
 
 setup(
     name='bbc1-lib-registry',
-    version='0.6',
+    version='0.7',
     description='General Registry library of Beyond Blockchain One',
     long_description=readme,
     url='https://github.com/beyond-blockchain',


### PR DESCRIPTION
Nested XML elements (for certificates, for example) can also have <digest/> so that it is easier to conceal part of documents for proof.
